### PR TITLE
fix up makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR := dist
 
 PLATFORMS := linux/amd64 darwin/amd64 darwin/arm64 windows/amd64
 
-.PHONY: all clean build release
+.PHONY: all clean build release test test-cover
 
 all: build
 
@@ -17,6 +17,12 @@ run:
 	@mkdir -p $(BUILD_DIR)
 	go build $(LDFLAGS) -o $(BUILD_DIR)/$(APP) ./main.go
 	./dist/ai-mr-comment
+
+test:
+	go test -v ./...
+
+test-cover:
+	go test -cover ./...
 
 clean:
 	rm -rf $(BUILD_DIR)
@@ -30,3 +36,4 @@ release: clean
 		echo "Building: $$OUTPUT"; \
 		GOOS=$$OS GOARCH=$$ARCH go build $(LDFLAGS) -o $$OUTPUT ./main.go; \
 	done
+


### PR DESCRIPTION
PR Title: Enhance Makefile with Test Commands
PR Summary: Added new targets for running tests and calculating test coverage in the Makefile.

## Key Changes:

- Added `test` and `test-cover` to the `.PHONY` target list.
- Introduced a `test` target to run tests with verbose output.
- Introduced a `test-cover` target to run tests with coverage analysis.

## Why These Changes:

These changes enable developers to easily run tests and assess code coverage directly from the Makefile, facilitating better testing practices and contributing to higher code quality.

## Review Checklist:

- [ ] Verify that the `test` target runs all tests with verbose output.
- [ ] Check that the `test-cover` target correctly calculates and displays test coverage.
- [ ] Ensure all Makefile commands are consistent and error-free.

## Notes:

Consider implementing continuous integration tools that utilize these new Makefile targets to automate testing and coverage reporting.